### PR TITLE
Add transform utilities and PROJ export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["crates/*", "apps/desktop/src-tauri"]
+default-members = ["crates/*"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/io/src/lib.rs
+++ b/crates/io/src/lib.rs
@@ -12,17 +12,17 @@ pub fn load_raster(path: &str) -> Result<String> {
     Ok(data_uri)
 }
 
-pub fn load_mbtiles(path: &str) -> Result<()> {
+pub fn load_mbtiles(_path: &str) -> Result<()> {
     // ... implementation ...
     Ok(())
 }
 
-pub fn load_cog(path: &str) -> Result<()> {
+pub fn load_cog(_path: &str) -> Result<()> {
     // ... implementation ...
     Ok(())
 }
 
-pub fn load_pdf(path: &str) -> Result<()> {
+pub fn load_pdf(_path: &str) -> Result<()> {
     // ... implementation ...
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add invert/compose helpers and PROJ string generation for similarity and affine transforms
- wire up Tauri command and UI button to copy PROJ pipelines
- show residuals table and global-only toggle in desktop app
- skip desktop crate during `cargo test` and clean up solver/io warnings

## Testing
- `cargo test`
- `cargo test -p solver`


------
https://chatgpt.com/codex/tasks/task_e_68953313f1d88320943f978f20b62c63