### PR TITLE
Add transform utilities and PROJ export

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,44 @@ report**. Every session becomes high‑quality training data for the ML model.
 - Local‑first storage; signed, append‑only operation logs ready for sync integration.
 
 See **docs/SPEC.md** and **docs/ROADMAP.md** for the complete specification and plan.
+
+## Running the Desktop App
+
+The Tauri desktop shell lives in `apps/desktop` and can be run locally for
+testing.
+
+### Prerequisites (Ubuntu)
+
+```bash
+sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev \
+    libayatana-appindicator3-dev librsvg2-dev libsoup2.4-dev
+```
+
+### Prerequisites (macOS)
+
+Install the Xcode command line tools and pnpm:
+
+```bash
+xcode-select --install
+brew install pnpm
+```
+
+### Prerequisites (Windows)
+
+Install the Visual Studio Build Tools with the "Desktop development with C++"
+workload and ensure the WebView2 runtime is present. Then install pnpm:
+
+```powershell
+npm install -g pnpm
+```
+
+### Launch
+
+```bash
+cd apps/desktop
+pnpm install
+pnpm run tauri:dev
+```
+
+This opens a window with map and reference panes where you can add pins,
+toggle the "Global only" solver and view residuals.

--- a/crates/io/src/lib.rs
+++ b/crates/io/src/lib.rs
@@ -12,17 +12,17 @@ pub fn load_raster(path: &str) -> Result<String> {
     Ok(data_uri)
 }
 
-pub fn load_mbtiles(path: &str) -> Result<()> {
+pub fn load_mbtiles(_path: &str) -> Result<()> {
     // ... implementation ...
     Ok(())
 }
 
-pub fn load_cog(path: &str) -> Result<()> {
+pub fn load_cog(_path: &str) -> Result<()> {
     // ... implementation ...
     Ok(())
 }
 
-pub fn load_pdf(path: &str) -> Result<()> {
+pub fn load_pdf(_path: &str) -> Result<()> {
     // ... implementation ...
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add invert/compose helpers and PROJ string generation for similarity and affine transforms
- wire up Tauri command and UI button to copy PROJ pipelines
- show residuals table and global-only toggle in desktop app
- re-enable desktop crate tests and document how to run the app locally
- fix reference path handling when exporting GeoTIFFs
- add macOS and Windows dependency setup instructions for the desktop app

## Testing
- `cargo test` *(fails: `javascriptcoregtk-4.0` missing)*
- `cargo test -p solver`


------
https://chatgpt.com/codex/tasks/task_e_68953313f1d88320943f978f20b62c63