### PR TITLE
Add georeferencing support and error unit toggles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,12 +40,6 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -155,7 +137,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -723,6 +705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1329,18 +1320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a4dcd69d35b2c87a7c83bce9af69fd65c9d68d3833a0ded568983928f3fc99"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,30 +2017,11 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "foldhash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2443,7 +2414,7 @@ dependencies = [
  "cog-core",
  "image 0.24.9",
  "pdfium-render",
- "rusqlite",
+ "proj",
  "thiserror 1.0.69",
 ]
 
@@ -2669,6 +2640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "libredox"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,12 +2658,21 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3115,6 +3101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3841,6 +3828,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
+name = "proj"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e0c01de214d7ea50ee6519969be9efdc6f0dc5ce6c64fbd4f054ea26d43ca4"
+dependencies = [
+ "geo-types",
+ "libc",
+ "num-traits",
+ "proj-sys",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "proj-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a208129995443a4c475464c33308274be1578993b0ad266c9139188ed0dc7e91"
+dependencies = [
+ "cmake",
+ "flate2",
+ "libsqlite3-sys",
+ "link-cplusplus",
+ "pkg-config",
+ "tar",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4178,20 +4192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
-dependencies = [
- "bitflags 2.9.1",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,7 +4222,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 approx = "0.5"
+proj = "0.30"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -34,14 +34,27 @@ function App() {
   }
 
   async function addPair(src: [number, number], dst: [number, number]) {
-    const c = { PointPair: { id: Date.now(), src, dst, weight: 1.0 } } as const;
+    const c = {
+      PointPair: {
+        id: Date.now(),
+        src,
+        dst,
+        dst_real: null,
+        dst_local: null,
+        weight: 1.0,
+      },
+    } as const;
     const list = (await invoke('add_constraint', { c })) as any[];
     const pairs = list.filter((x) => 'PointPair' in x).map((x) => x.PointPair);
     setConstraints(pairs);
   }
 
   async function solve(method: 'similarity' | 'affine') {
-    const [stack, metrics] = (await invoke('solve_global', { method })) as [
+    const [stack, metrics] = (await invoke('solve_global', {
+      method,
+      error_unit: 'pixels',
+      map_scale: null,
+    })) as [
       any,
       { rmse: number; p90_error: number; residuals_by_id: [number, number][] }
     ];

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -8,8 +8,9 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 thiserror.workspace = true
-rusqlite = "0.30"
+# rusqlite removed to avoid sqlite linkage conflicts; add back when MBTiles support implemented
 cog-core = "0.2"
 pdfium-render = "0.8"
 image = "0.24"
 base64 = "0.21"
+proj.workspace = true

--- a/crates/io/src/lib.rs
+++ b/crates/io/src/lib.rs
@@ -1,7 +1,58 @@
 use anyhow::Result;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use image::ImageFormat;
+use proj::Proj;
 use std::io::Cursor;
+
+#[derive(Debug, Clone)]
+pub struct Georef {
+    pub affine: [f64; 6],
+    pub wkt: Option<String>,
+}
+
+/// Read world file and optional PRJ file for a reference image.
+pub fn read_georeferencing(path_without_ext: &str) -> Result<Georef> {
+    use std::fs::read_to_string;
+    use std::path::PathBuf;
+    let affine = read_world_file(path_without_ext)?;
+    let mut prj = PathBuf::from(path_without_ext);
+    prj.set_extension("prj");
+    let wkt = read_to_string(&prj).ok();
+    Ok(Georef { affine, wkt })
+}
+
+/// Convert a reference pixel coordinate to real-world coordinates using the
+/// affine transform from the world file.
+pub fn pixel_to_world(geo: &Georef, px: [f64; 2]) -> [f64; 2] {
+    let [a, b, d, e, c, f] = geo.affine;
+    let x = a * px[0] + b * px[1] + c;
+    let y = d * px[0] + e * px[1] + f;
+    [x, y]
+}
+
+/// Convert a reference pixel coordinate to a local meter-plane coordinate
+/// relative to `origin_px`.
+pub fn pixel_to_local_meters(
+    geo: &Georef,
+    px: [f64; 2],
+    origin_px: [f64; 2],
+) -> Result<Option<[f64; 2]>> {
+    let world = pixel_to_world(geo, px);
+    let origin_world = pixel_to_world(geo, origin_px);
+    let wkt = match &geo.wkt {
+        Some(w) => w,
+        None => return Ok(None),
+    };
+    // Convert world coordinates to WGS84
+    let to_wgs84 = Proj::new_known_crs(wkt, "EPSG:4326", None)?;
+    let (lon, lat) = to_wgs84.convert((world[0], world[1]))?;
+    let (origin_lon, origin_lat) = to_wgs84.convert((origin_world[0], origin_world[1]))?;
+    // Build local azimuthal equidistant projection centered at origin
+    let aeqd_def = format!("+proj=aeqd +lat_0={} +lon_0={}", origin_lat, origin_lon);
+    let to_local = Proj::new_known_crs("EPSG:4326", &aeqd_def, None)?;
+    let (x, y) = to_local.convert((lon, lat))?;
+    Ok(Some([x, y]))
+}
 
 pub fn load_raster(path: &str) -> Result<String> {
     // Load raster and return as PNG data URI for UI display

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -3,11 +3,28 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ConstraintKind {
     Point { id: u64, point: [f64; 2], weight: f64 },
-    PointPair { id: u64, src: [f64; 2], dst: [f64; 2], weight: f64 },
+    PointPair {
+        id: u64,
+        src: [f64; 2],
+        dst: [f64; 2],
+        /// Real-world coordinates derived from the reference georeferencing (CRS units)
+        dst_real: Option<[f64; 2]>,
+        /// Local meter-plane coordinates relative to the reference origin
+        dst_local: Option<[f64; 2]>,
+        weight: f64,
+    },
     Polyline { id: u64, points: Vec<[f64; 2]>, weight: f64 },
     Polygon { id: u64, points: Vec<[f64; 2]>, weight: f64 },
     AnisotropicPin { id: u64, point: [f64; 2], sigma_major: f64, sigma_minor: f64, angle: f64 },
     Anchor { id: u64, point: [f64; 2] },
+}
+
+/// Units for reporting positional error metrics
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorUnit {
+    Pixels,
+    Meters,
+    MapMillimeters,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -34,9 +51,23 @@ pub struct QualityMetrics {
     pub residuals: Vec<f64>,
     pub residuals_by_id: Vec<(u64, f64)>,
     pub warnings: Vec<String>,
+    /// Units used for error reporting
+    pub unit: ErrorUnit,
+    /// Optional map scale denominator (e.g. 10000 for 1:10000)
+    pub map_scale: Option<f64>,
 }
 impl Default for QualityMetrics {
-    fn default() -> Self { Self { rmse: 0.0, p90_error: 0.0, residuals: Vec::new(), residuals_by_id: Vec::new(), warnings: Vec::new() } }
+    fn default() -> Self {
+        Self {
+            rmse: 0.0,
+            p90_error: 0.0,
+            residuals: Vec::new(),
+            residuals_by_id: Vec::new(),
+            warnings: Vec::new(),
+            unit: ErrorUnit::Pixels,
+            map_scale: None,
+        }
+    }
 }
 
 // Placeholder structs for transform kinds
@@ -60,6 +91,46 @@ impl ConstraintKind {
             | ConstraintKind::Polygon { id, .. }
             | ConstraintKind::AnisotropicPin { id, .. }
             | ConstraintKind::Anchor { id, .. } => *id,
+        }
+    }
+}
+
+impl QualityMetrics {
+    /// Convert metrics to the requested unit. `pixel_size` is the ground
+    /// distance represented by a single reference pixel in meters. When
+    /// converting to or from `MapMillimeters`, `map_scale` must be provided
+    /// (denominator, e.g. 10000 for 1:10000).
+    pub fn convert_units(
+        &mut self,
+        pixel_size: f64,
+        map_scale: Option<f64>,
+        target: ErrorUnit,
+    ) {
+        let mut factor = 1.0;
+        match (self.unit, target) {
+            (ErrorUnit::Pixels, ErrorUnit::Meters) => factor = pixel_size,
+            (ErrorUnit::Meters, ErrorUnit::Pixels) => factor = 1.0 / pixel_size,
+            (ErrorUnit::Pixels, ErrorUnit::MapMillimeters) => {
+                if let Some(s) = map_scale { factor = pixel_size * (1000.0 / s); }
+            }
+            (ErrorUnit::MapMillimeters, ErrorUnit::Pixels) => {
+                if let Some(s) = map_scale { factor = (s / 1000.0) / pixel_size; }
+            }
+            (ErrorUnit::Meters, ErrorUnit::MapMillimeters) => {
+                if let Some(s) = map_scale { factor = 1000.0 / s; }
+            }
+            (ErrorUnit::MapMillimeters, ErrorUnit::Meters) => {
+                if let Some(s) = map_scale { factor = s / 1000.0; }
+            }
+            _ => {}
+        }
+        self.rmse *= factor;
+        self.p90_error *= factor;
+        for r in &mut self.residuals { *r *= factor; }
+        for (_, r) in &mut self.residuals_by_id { *r *= factor; }
+        self.unit = target;
+        if target == ErrorUnit::MapMillimeters {
+            self.map_scale = map_scale;
         }
     }
 }


### PR DESCRIPTION
## Summary
- read world/prj georeferencing and compute real & local coordinates using PROJ
- store real-world and local meter-plane coords on point pairs
- toggle error metrics between pixels, meters, and map mm with optional scale

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689549145d908320bfa175574a13d00d